### PR TITLE
remote/dev apply: ship only files the plan references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "lusid-system",
  "lusid-tree",
  "lusid-vm",
+ "path-clean",
  "ratatui",
  "rimu",
  "rimu-interop",
@@ -3325,6 +3326,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pbkdf2"

--- a/lusid/Cargo.toml
+++ b/lusid/Cargo.toml
@@ -11,6 +11,7 @@ lusid-machine = { path = "../machine", version = "0.2" }
 lusid-params = { path = "../params", version = "0.2" }
 lusid-plan = { path = "../plan", version = "0.2" }
 lusid-render = { path = "../render", version = "0.2" }
+lusid-resource = { path = "../resource", version = "0.2" }
 lusid-tree = { path = "../tree", version = "0.2" }
 lusid-secrets = { path = "../secrets", version = "0.2" }
 lusid-ssh = { path = "../ssh", version = "0.2" }
@@ -21,6 +22,7 @@ comfy-table = "7.2.2"
 clap.workspace = true
 crossterm = "0.29"
 displaydoc.workspace = true
+path-clean = "1.0"
 ratatui = "0.30"
 rimu.workspace = true
 rimu-interop = { path = "../rimu-interop", version = "0.2" }
@@ -37,4 +39,3 @@ vt100.workspace = true
 
 [dev-dependencies]
 lusid-operation = { path = "../operation", version = "0.2" }
-lusid-resource = { path = "../resource", version = "0.2" }

--- a/lusid/src/config.rs
+++ b/lusid/src/config.rs
@@ -152,6 +152,7 @@ impl Config {
                 os,
                 vm: _,
                 remote,
+                user: _,
             } = machine;
             let remote_cell = match remote {
                 Some(r) => format!("{}@{}:{}", r.user(), r.host, r.port()),

--- a/lusid/src/lib.rs
+++ b/lusid/src/lib.rs
@@ -8,6 +8,7 @@
 mod config;
 mod embedded;
 mod tui;
+mod upload_set;
 
 use std::{
     borrow::Cow,
@@ -38,6 +39,17 @@ use tokio::io::AsyncReadExt;
 use crate::config::{Config, ConfigError, MachineConfig};
 use crate::embedded::EmbeddedError;
 use crate::tui::{TuiError, is_tty_stdout, plain, tui};
+use crate::upload_set::UploadSetError;
+
+use std::collections::BTreeSet;
+
+use lusid_ctx::ContextError;
+use lusid_machine::Machine;
+use lusid_params::ParamsContext;
+use lusid_plan::{PlanError, PlanId};
+use lusid_store::Store;
+use rimu::SourceId;
+use rimu_interop::{ToRimuError, to_rimu};
 
 /// Parsed CLI. The `lusid-apply` worker is baked into this binary at build
 /// time for each supported target arch (see [`crate::embedded`] /
@@ -256,6 +268,32 @@ pub enum AppError {
 
     #[error("failed to install lusid-apply on target (sudo -n exit {exit:?}): {stderr}")]
     InstallApplyBinary { exit: Option<u32>, stderr: String },
+
+    #[error("failed to set up planning context for upload discovery: {0}")]
+    DiscoveryContext(#[from] ContextError),
+
+    #[error(
+        "operator-side plan discovery failed for {machine_id:?}; fix the plan and \
+         re-run before any network work happens. Source: {source}"
+    )]
+    DiscoveryPlan {
+        machine_id: String,
+        #[source]
+        source: PlanError,
+    },
+
+    #[error("failed to convert per-machine params to Rimu value: {0}")]
+    DiscoveryParams(#[from] ToRimuError),
+
+    #[error(transparent)]
+    UploadSet(#[from] UploadSetError),
+
+    #[error("failed to stat upload manifest entry {path}: {source}", path = path.display())]
+    UploadManifestStat {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error(
         "interactive confirmation requires a TTY; pass --yes / -y to auto-accept \
@@ -529,16 +567,32 @@ async fn cmd_remote_apply(
         })?;
     validate_ssh_user(remote.user())?;
 
+    let project_root = config.root().to_path_buf();
+    // Discover the upload manifest before any network work: plan failures
+    // surface as plain errors, not opaque SFTP misses partway through an apply.
+    let DiscoveryOutcome { manifest, plan_rel } = discover_upload_manifest(
+        &project_root,
+        &plan,
+        params.as_ref(),
+        &machine,
+        remote.user(),
+        &machine_id,
+    )
+    .await?;
+
     let mut ssh = connect_remote(remote).await?;
 
     let guest_secrets_dir = format!("{REMOTE_ROOT}/secrets");
-    let guest_plan_dir = format!("{REMOTE_ROOT}/plan");
+    let guest_project_dir = format!("{REMOTE_ROOT}/project");
     let guest_apply_path = format!("{REMOTE_ROOT}/lusid-apply");
 
     // 1. Bootstrap (non-root only): create dirs and chown them so SFTP can write.
     if !remote.is_root() {
         bootstrap_remote_dirs(&mut ssh, remote.user(), REMOTE_ROOT).await?;
     }
+    // Sweep the legacy `<root>/plan` mirror so it doesn't linger as dead state
+    // after this apply switches to `<root>/project`.
+    clear_legacy_plan_dir(&mut ssh, REMOTE_ROOT, remote.is_root()).await;
 
     // 2. Pre-cleanup: drop any leftover ciphertexts from a previous run.
     //    Best-effort - never fail the apply over this. We log either way so a
@@ -593,14 +647,8 @@ async fn cmd_remote_apply(
         false
     };
 
-    // 4. Upload plan dir.
-    let plan_local_dir = plan.parent().unwrap();
-    let plan_filename = plan.file_name().unwrap().to_string_lossy().to_string();
-    ssh.sync(SshVolume::DirPath {
-        local: plan_local_dir.to_path_buf(),
-        remote: guest_plan_dir.clone(),
-    })
-    .await?;
+    // 4. Mirror the discovered upload manifest under <root>/project/.
+    upload_manifest(&mut ssh, &project_root, &manifest, &guest_project_dir).await?;
 
     // 5. Upload binary. For non-root, install root-owned via sudo to defend
     //    against between-SFTP-and-exec swaps. The embedded bytes are a
@@ -633,20 +681,16 @@ async fn cmd_remote_apply(
         }
     }
 
-    // 6. Build the apply command.
-    //
-    // TODO(cc): audit `--root` semantics for remote/dev apply. We pass the
-    // operator's local path, but `lusid-apply` uses it on the guest to
-    // anchor relative `host-path` resolution and the cache dir - and plans
-    // typically anchor host-paths on the source span (the uploaded plan
-    // file's location), making the operator-side path largely ineffective.
+    // 6. Build the apply command. `--root` now points at the project mirror
+    // on the target (was previously the operator's local path, which the
+    // guest never had access to). `--plan` is the mirrored plan file location.
+    let guest_plan_path = format!("{guest_project_dir}/{}", plan_rel.to_string_lossy());
     let log = &config.log;
     let mut command = format!(
-        "{} --root {} --plan {}/{} --log {}",
+        "{} --root {} --plan {} --log {}",
         shell_words::quote(&guest_apply_path),
-        shell_words::quote(&config.root().to_string_lossy()),
-        shell_words::quote(&guest_plan_dir),
-        shell_words::quote(&plan_filename),
+        shell_words::quote(&guest_project_dir),
+        shell_words::quote(&guest_plan_path),
         shell_words::quote(log),
     );
     if forward_secrets {
@@ -926,7 +970,7 @@ async fn wait_for_vm_ready(ssh: &mut Ssh, ready_check: Option<&str>) -> Result<(
     Ok(())
 }
 
-/// Create `/var/lib/lusid` and its `plan` / `secrets` subdirs on the target
+/// Create `/var/lib/lusid` and its `project` / `secrets` subdirs on the target
 /// and chown them to the SSH user. Idempotent. Only called when `user` is
 /// non-root; root SFTP can mkdir directly via `sftp_mkdirs`.
 ///
@@ -935,14 +979,145 @@ async fn wait_for_vm_ready(ssh: &mut Ssh, ready_check: Option<&str>) -> Result<(
 /// if the validator is ever relaxed.
 async fn bootstrap_remote_dirs(ssh: &mut Ssh, user: &str, root: &str) -> Result<(), AppError> {
     let cmd = format!(
-        "sudo -n mkdir -p {root} {root}/plan {root}/secrets \
-         && sudo -n chown {user} {root} {root}/plan {root}/secrets",
+        "sudo -n mkdir -p {root} {root}/project {root}/secrets \
+         && sudo -n chown {user} {root} {root}/project {root}/secrets",
         root = shell_words::quote(root),
         user = shell_words::quote(user),
     );
     let (exit, _stdout, stderr) = ssh_run(ssh, &cmd).await?;
     if exit != Some(0) {
         return Err(AppError::BootstrapRemoteDir { exit, stderr });
+    }
+    Ok(())
+}
+
+/// Best-effort removal of the legacy `<root>/plan` directory left by pre-
+/// `0.2.x` apply binaries. Failures are logged but never propagate - if the
+/// dir is already gone, never existed, or sudo is unavailable, the apply
+/// continues as if nothing happened. The leading `test -d` keeps `sudo` out
+/// of the audit log on the common case where the legacy dir was already
+/// cleaned up or never existed.
+async fn clear_legacy_plan_dir(ssh: &mut Ssh, root: &str, is_root: bool) {
+    let path = format!("{root}/plan");
+    let path_q = shell_words::quote(&path);
+    let cmd = if is_root {
+        format!("[ -d {path_q} ] && rm -rf {path_q} || true")
+    } else {
+        format!("[ -d {path_q} ] && sudo -n rm -rf {path_q} || true")
+    };
+    if let Err(err) = ssh_run(ssh, &cmd).await {
+        tracing::debug!(?err, %path, "legacy plan dir cleanup failed");
+    }
+}
+
+/// Run the planner offline (with a synthesised [`System`] derived from the
+/// machine config) to discover which files the plan references, then build a
+/// manifest of paths relative to the project root. Fails loudly before any
+/// network/SSH work so a missing source surfaces with a real error, not a
+/// remote SFTP failure.
+/// Output of [`discover_upload_manifest`]. `plan_rel` is computed with the
+/// same lexical normalisation as `manifest` so the caller can hand it to the
+/// guest as a project-relative `--plan` argument without risking divergence
+/// from how the manifest was rebased.
+struct DiscoveryOutcome {
+    manifest: BTreeSet<PathBuf>,
+    plan_rel: PathBuf,
+}
+
+async fn discover_upload_manifest(
+    project_root: &Path,
+    plan_path: &Path,
+    params: Option<&toml::Value>,
+    machine: &Machine,
+    default_user: &str,
+    machine_id: &str,
+) -> Result<DiscoveryOutcome, AppError> {
+    // The synthesised `System` is operator-side only - just to drive the
+    // planner deterministically for file discovery. The guest re-plans
+    // against its own `System::get()` at apply time, so any drift between
+    // synth and reality lives there.
+    let system = upload_set::synthesize_system(machine, default_user);
+
+    let params_value = match params {
+        None => None,
+        Some(toml_val) => {
+            let json_val: serde_json::Value = serde_json::to_value(toml_val)?;
+            Some(to_rimu(json_val, SourceId::empty())?)
+        }
+    };
+
+    // Mirror `lusid-apply`'s guest-mode `ParamsContext`: relative `host-path`
+    // strings in CLI params have no source span to anchor against, so reject
+    // them here to keep the operator-side discovery diagnostics aligned with
+    // what the target would emit at apply time.
+    let params_ctx =
+        ParamsContext::new(project_root.to_path_buf()).forbid_cli_relative_host_paths();
+
+    let ctx = Context::create(project_root)?;
+    let mut store = Store::new(ctx.paths().cache_dir());
+    let plan_id = PlanId::Path(plan_path.to_path_buf());
+
+    let plan_tree = lusid_plan::plan(plan_id, params_value, &params_ctx, &mut store, &system)
+        .await
+        .map_err(|source| AppError::DiscoveryPlan {
+            machine_id: machine_id.to_string(),
+            source,
+        })?;
+
+    let host_paths = upload_set::collect_host_paths(&plan_tree);
+    let manifest = upload_set::build_manifest(project_root, store.reads(), &host_paths)?;
+    let plan_rel = upload_set::relativize(project_root, plan_path)?;
+    Ok(DiscoveryOutcome { manifest, plan_rel })
+}
+
+/// Default username for the dev VM's cloud-init user, used at plan-discovery
+/// time before the VM has booted. Mirrors `vm/images.toml` per distro; an
+/// override on `[machines.<id>.user.name]` takes precedence inside
+/// [`upload_set::synthesize_system`]. The wildcard arm is a safety net for
+/// future `Linux` / `Os` variants - the user override should be set
+/// explicitly until images.toml learns about the new distro.
+fn dev_cloud_init_user(machine: &Machine) -> &'static str {
+    use lusid_system::{Linux, Os};
+    match &machine.os {
+        Os::Linux(Linux::Debian { .. }) => "debian",
+        Os::Linux(Linux::Ubuntu { .. }) => "ubuntu",
+        Os::Linux(Linux::Arch) => "arch",
+        other => {
+            tracing::warn!(
+                ?other,
+                "unknown distro for dev planning default user; falling back to root \
+                 (set `[machines.<id>.user.name]` in lusid.toml to override)"
+            );
+            "root"
+        }
+    }
+}
+
+/// Mirror each manifest entry under `guest_dir`, preserving relative layout.
+/// Stats each local path to pick between `SshVolume::DirPath` (recurses) and
+/// `SshVolume::FilePath` (single file).
+async fn upload_manifest(
+    ssh: &mut Ssh,
+    project_root: &Path,
+    manifest: &BTreeSet<PathBuf>,
+    guest_dir: &str,
+) -> Result<(), AppError> {
+    for rel in manifest {
+        let local = project_root.join(rel);
+        let metadata =
+            tokio::fs::metadata(&local)
+                .await
+                .map_err(|source| AppError::UploadManifestStat {
+                    path: local.clone(),
+                    source,
+                })?;
+        let remote = format!("{guest_dir}/{}", rel.to_string_lossy());
+        let volume = if metadata.is_dir() {
+            SshVolume::DirPath { local, remote }
+        } else {
+            SshVolume::FilePath { local, remote }
+        };
+        ssh.sync(volume).await?;
     }
     Ok(())
 }
@@ -993,8 +1168,24 @@ async fn cmd_dev_apply(
         params,
     } = config.get_machine(&machine_id)?;
 
-    let root = config.root();
-    let mut ctx = Context::create(root).unwrap();
+    let project_root = config.root().to_path_buf();
+    // Run discovery before booting the VM: a plan error here costs nothing,
+    // a plan error after `Vm::run` costs ~30s and a half-launched VM. The
+    // default planning user matches what cloud-init creates from
+    // `vm/images.toml` for the machine's distro; the synthesised
+    // [`System::user`] is otherwise the Debian-convention default.
+    let dev_default_user = dev_cloud_init_user(&machine);
+    let DiscoveryOutcome { manifest, plan_rel } = discover_upload_manifest(
+        &project_root,
+        &plan,
+        params.as_ref(),
+        &machine,
+        dev_default_user,
+        &machine_id,
+    )
+    .await?;
+
+    let mut ctx = Context::create(&project_root).unwrap();
 
     let instance_id = &machine_id;
     let ports = vec![];
@@ -1021,20 +1212,13 @@ async fn cmd_dev_apply(
     wait_for_vm_ready(&mut ssh, vm.ready_check.as_deref()).await?;
 
     let dev_dir = format!("/home/{}", vm.user);
-    let plan_dir = plan.parent().unwrap();
-    let plan_filename = plan.file_name().unwrap().to_string_lossy();
+    let guest_project_dir = format!("{dev_dir}/project");
 
-    let mut volumes = vec![
-        SshVolume::FileBytes {
-            local: Cow::Borrowed(embedded::embedded_lusid_apply(machine.arch)?),
-            permissions: Some(0o755),
-            remote: format!("{dev_dir}/lusid-apply"),
-        },
-        SshVolume::DirPath {
-            local: plan_dir.to_path_buf(),
-            remote: format!("{dev_dir}/plan"),
-        },
-    ];
+    let mut volumes = vec![SshVolume::FileBytes {
+        local: Cow::Borrowed(embedded::embedded_lusid_apply(machine.arch)?),
+        permissions: Some(0o755),
+        remote: format!("{dev_dir}/lusid-apply"),
+    }];
 
     // Secrets forwarding. The dev VM SHADOWS the production target named
     // by `--machine`: it should see exactly the [files]-scoped subset
@@ -1092,10 +1276,13 @@ async fn cmd_dev_apply(
         false
     };
 
+    let guest_plan_path = format!("{guest_project_dir}/{}", plan_rel.to_string_lossy());
     let log = &config.log;
     let mut command = format!(
-        "{dev_dir}/lusid-apply --root {} --plan {dev_dir}/plan/{plan_filename} --log {log}",
-        root.display()
+        "{}/lusid-apply --root {} --plan {} --log {log}",
+        dev_dir,
+        shell_words::quote(&guest_project_dir),
+        shell_words::quote(&guest_plan_path),
     );
     if forward_secrets {
         command.push_str(&format!(
@@ -1115,9 +1302,20 @@ async fn cmd_dev_apply(
         command.push_str(&format!(" --params {}", shell_words::quote(&params_json)));
     }
 
+    // Best-effort: clean up the legacy `{dev_dir}/plan` mirror left by
+    // pre-0.2.x dev apply. Failures don't propagate; the VM user owns
+    // `dev_dir` so `rm -rf` doesn't need sudo.
+    let legacy_plan = format!("{dev_dir}/plan");
+    let legacy_plan_q = shell_words::quote(&legacy_plan);
+    let cleanup_cmd = format!("[ -d {legacy_plan_q} ] && rm -rf {legacy_plan_q} || true");
+    if let Err(err) = ssh_run(&mut ssh, &cleanup_cmd).await {
+        tracing::debug!(?err, %legacy_plan, "legacy plan dir cleanup failed");
+    }
+
     for volume in volumes {
         ssh.sync(volume).await?;
     }
+    upload_manifest(&mut ssh, &project_root, &manifest, &guest_project_dir).await?;
 
     let mut handle = ssh.command(&command).await?;
     let stdin = Box::pin(handle.channel.stdin());

--- a/lusid/src/upload_set.rs
+++ b/lusid/src/upload_set.rs
@@ -1,0 +1,343 @@
+//! Local plan discovery for `remote apply` and `dev apply`.
+//!
+//! Runs the planner on the operator with a synthesised [`System`] to learn
+//! exactly which files the plan touches - plan sources (recorded by the
+//! [`Store`] read tracker) and operator-side host-path sources read off the
+//! resulting [`PlanTree`]. The caller mirrors those paths onto the target
+//! instead of shipping the whole plan directory.
+//!
+//! The synthesised [`System`] is "real enough" for planning but won't always
+//! match what [`System::get`] would produce on the target (user-private-group
+//! distros are the assumed default; override per-machine in `lusid.toml` via
+//! the `[machines.<id>.user]` block when that's wrong). Plans that branch on
+//! `system.user.primary_group` or other fields that differ between the
+//! synthetic and real systems will produce a different upload set than the
+//! target's re-plan and may fail at apply with missing-file errors.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use displaydoc::Display;
+use lusid_machine::Machine;
+use lusid_plan::PlanTree;
+use lusid_resource::ResourceParams;
+use lusid_resource::directory::DirectoryParams;
+use lusid_resource::file::FileParams;
+use lusid_store::StoreItemId;
+use lusid_system::{System, User};
+use lusid_tree::Tree;
+use path_clean::PathClean;
+use rimu::Span;
+use thiserror::Error;
+
+#[derive(Debug, Error, Display)]
+pub enum UploadSetError {
+    /// host-path source `{path}` is outside the project root `{root}` and cannot be mirrored. Move the source under the project root or restructure the plan to reference it from there.
+    PathOutsideRoot {
+        path: PathBuf,
+        root: PathBuf,
+        span: Option<Span>,
+    },
+
+    /// path `{path}` could not be made absolute against project root `{root}`; planner produced an unexpected shape
+    PathNotAbsolute {
+        path: PathBuf,
+        root: PathBuf,
+        span: Option<Span>,
+    },
+}
+
+/// Resolve `path` to a project-relative form: absolutise against `root` if
+/// needed, lexically clean (`..` and `.`), and `strip_prefix(root)`. Errors if
+/// the result escapes `root` (e.g. via leading `..`s) or somehow remains
+/// non-absolute. Shared between [`build_manifest`] and callers that need the
+/// same relativisation for plan paths handed back to the apply command line.
+pub fn relativize(root: &Path, path: &Path) -> Result<PathBuf, UploadSetError> {
+    let root = make_absolute(root).clean();
+    rebase(&root, path, None)
+}
+
+/// Build the synthetic [`System`] the operator uses to plan offline for a
+/// target. Convention defaults match Debian/Arch user-private-group setups
+/// (`home = /home/<name>`, `primary_group = <name>`, `/root` for root). Per-
+/// machine `[machines.<id>.user]` overrides take precedence field-by-field.
+pub fn synthesize_system(machine: &Machine, default_user: &str) -> System {
+    let override_user = machine.user.as_ref();
+    let name = override_user
+        .and_then(|u| u.name.clone())
+        .unwrap_or_else(|| default_user.to_string());
+    let home = override_user
+        .and_then(|u| u.home.clone())
+        .unwrap_or_else(|| {
+            if name == "root" {
+                PathBuf::from("/root")
+            } else {
+                PathBuf::from(format!("/home/{name}"))
+            }
+        });
+    let primary_group = override_user
+        .and_then(|u| u.primary_group.clone())
+        .unwrap_or_else(|| name.clone());
+
+    System {
+        hostname: machine.hostname.clone(),
+        arch: machine.arch,
+        os: machine.os.clone(),
+        user: User {
+            name,
+            home,
+            primary_group,
+        },
+    }
+}
+
+/// Walk a planned tree and collect every operator-side host-path source with
+/// its span (for diagnostics).
+///
+/// Today only `@resource/file` and `@resource/directory` carry an operator-
+/// side `source`. Note(cc): if a new `ResourceParams` variant grows an
+/// operator-side path field, extend the match in `host_source` so the file
+/// ships with remote/dev apply. `PlanMeta::handlers` holds operations
+/// (`@operation/command` etc.) which do not currently reference operator-side
+/// bytes - intentionally not walked.
+pub fn collect_host_paths(tree: &PlanTree<ResourceParams>) -> Vec<(PathBuf, Span)> {
+    let mut out = Vec::new();
+    walk(tree, &mut out);
+    out
+}
+
+fn walk(tree: &PlanTree<ResourceParams>, out: &mut Vec<(PathBuf, Span)>) {
+    match tree {
+        Tree::Branch { children, .. } => {
+            for child in children {
+                walk(child, out);
+            }
+        }
+        Tree::Leaf { node, .. } => {
+            if let Some(entry) = host_source(node) {
+                out.push(entry);
+            }
+        }
+    }
+}
+
+fn host_source(params: &ResourceParams) -> Option<(PathBuf, Span)> {
+    match params {
+        ResourceParams::File(FileParams::Sourced {
+            source,
+            source_span,
+            ..
+        })
+        | ResourceParams::File(FileParams::Linked {
+            source,
+            source_span,
+            ..
+        })
+        | ResourceParams::Directory(DirectoryParams::Sourced {
+            source,
+            source_span,
+            ..
+        })
+        | ResourceParams::Directory(DirectoryParams::Linked {
+            source,
+            source_span,
+            ..
+        }) => Some((source.as_path().to_path_buf(), source_span.clone())),
+        _ => None,
+    }
+}
+
+/// Build the upload manifest: a deduped, sorted set of paths relative to
+/// `root`. Both plan sources (from [`lusid_store::Store::reads`]) and host-
+/// path sources are absolutised against `root`, lexically cleaned (resolving
+/// `..` segments so the same file referenced via different traversals
+/// dedupes), and rebased to relative.
+///
+/// The returned [`BTreeSet`]'s lexicographic order is load-bearing for
+/// callers: parent directories sort before their children, so iterating in
+/// natural order uploads `DirPath` mirrors before any sibling `FilePath`
+/// upload could land inside the same subtree.
+pub fn build_manifest(
+    root: &Path,
+    plan_reads: &[StoreItemId],
+    host_paths: &[(PathBuf, Span)],
+) -> Result<BTreeSet<PathBuf>, UploadSetError> {
+    let root = make_absolute(root).clean();
+    let mut out = BTreeSet::new();
+    for id in plan_reads {
+        let StoreItemId::LocalFile(path) = id;
+        out.insert(rebase(&root, path, None)?);
+    }
+    for (path, span) in host_paths {
+        out.insert(rebase(&root, path, Some(span.clone()))?);
+    }
+    Ok(out)
+}
+
+fn rebase(root: &Path, path: &Path, span: Option<Span>) -> Result<PathBuf, UploadSetError> {
+    let absolutised = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+    let cleaned = absolutised.clean();
+    if !cleaned.is_absolute() {
+        return Err(UploadSetError::PathNotAbsolute {
+            path: cleaned,
+            root: root.to_path_buf(),
+            span,
+        });
+    }
+    cleaned
+        .strip_prefix(root)
+        .map(PathBuf::from)
+        .map_err(|_| UploadSetError::PathOutsideRoot {
+            path: cleaned,
+            root: root.to_path_buf(),
+            span,
+        })
+}
+
+fn make_absolute(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lusid_system::{Arch, Hostname, Linux, Os};
+    use rimu::SourceId;
+
+    fn debian_machine() -> Machine {
+        Machine {
+            hostname: Hostname::from("web-a".to_string()),
+            arch: Arch::X86_64,
+            os: Os::Linux(Linux::Debian { version: 13 }),
+            vm: None,
+            remote: None,
+            user: None,
+        }
+    }
+
+    fn empty_span() -> Span {
+        Span::new(SourceId::empty(), 0, 0)
+    }
+
+    fn store(p: &str) -> StoreItemId {
+        StoreItemId::LocalFile(PathBuf::from(p))
+    }
+
+    #[test]
+    fn manifest_dedupes_paths_with_dotdot_segments() {
+        let root = PathBuf::from("/tmp/proj");
+        let plan_reads = vec![
+            store("/tmp/proj/servers/rpi4b-1/../../plans/base.lusid"),
+            store("/tmp/proj/plans/base.lusid"),
+        ];
+        let manifest = build_manifest(&root, &plan_reads, &[]).unwrap();
+        assert_eq!(manifest.len(), 1);
+        assert!(manifest.contains(Path::new("plans/base.lusid")));
+    }
+
+    #[test]
+    fn manifest_collects_plan_and_host_paths() {
+        let root = PathBuf::from("/tmp/proj");
+        let plan_reads = vec![store("/tmp/proj/servers/web/web.lusid")];
+        let host_paths = vec![(
+            PathBuf::from("/tmp/proj/servers/web/files/zshrc"),
+            empty_span(),
+        )];
+        let manifest = build_manifest(&root, &plan_reads, &host_paths).unwrap();
+        assert!(manifest.contains(Path::new("servers/web/web.lusid")));
+        assert!(manifest.contains(Path::new("servers/web/files/zshrc")));
+    }
+
+    #[test]
+    fn manifest_sorts_parent_dirs_before_children() {
+        let root = PathBuf::from("/tmp/proj");
+        let host_paths = vec![
+            (PathBuf::from("/tmp/proj/files/zshrc/inner"), empty_span()),
+            (PathBuf::from("/tmp/proj/files"), empty_span()),
+        ];
+        let manifest = build_manifest(&root, &[], &host_paths).unwrap();
+        let collected: Vec<_> = manifest.iter().collect();
+        assert_eq!(collected[0], Path::new("files"));
+        assert_eq!(collected[1], Path::new("files/zshrc/inner"));
+    }
+
+    #[test]
+    fn manifest_errors_when_path_escapes_root() {
+        let root = PathBuf::from("/tmp/proj");
+        let host_paths = vec![(PathBuf::from("/etc/passwd"), empty_span())];
+        let err = build_manifest(&root, &[], &host_paths).unwrap_err();
+        assert!(matches!(err, UploadSetError::PathOutsideRoot { .. }));
+    }
+
+    #[test]
+    fn manifest_errors_when_dotdot_climbs_above_root() {
+        let root = PathBuf::from("/tmp/proj");
+        let plan_reads = vec![store("/tmp/proj/../escaped.lusid")];
+        let err = build_manifest(&root, &plan_reads, &[]).unwrap_err();
+        assert!(matches!(err, UploadSetError::PathOutsideRoot { .. }));
+    }
+
+    #[test]
+    fn manifest_normalizes_host_path_resolved_via_dotdot_in_span_source() {
+        // Sub-plan loaded via `../../plans/base.lusid` resolves an inline
+        // host path against the sub-plan's directory. The resulting absolute
+        // path keeps the `..` segments verbatim; lexical normalisation
+        // collapses them back to the canonical location under the project
+        // root.
+        let root = PathBuf::from("/tmp/proj");
+        let host_paths = vec![(
+            PathBuf::from("/tmp/proj/servers/web/../../plans/files/zshrc"),
+            empty_span(),
+        )];
+        let manifest = build_manifest(&root, &[], &host_paths).unwrap();
+        assert!(manifest.contains(Path::new("plans/files/zshrc")));
+        assert_eq!(manifest.len(), 1);
+    }
+
+    #[test]
+    fn relativize_agrees_with_manifest_normalization() {
+        let root = PathBuf::from("/tmp/proj");
+        let plan = PathBuf::from("/tmp/proj/./servers/web/web.lusid");
+        let rel = relativize(&root, &plan).unwrap();
+        assert_eq!(rel, Path::new("servers/web/web.lusid"));
+    }
+
+    #[test]
+    fn synthesize_system_applies_debian_defaults_for_named_user() {
+        let sys = synthesize_system(&debian_machine(), "mikey");
+        assert_eq!(sys.user.name, "mikey");
+        assert_eq!(sys.user.home, PathBuf::from("/home/mikey"));
+        assert_eq!(sys.user.primary_group, "mikey");
+    }
+
+    #[test]
+    fn synthesize_system_uses_root_home_for_root() {
+        let sys = synthesize_system(&debian_machine(), "root");
+        assert_eq!(sys.user.home, PathBuf::from("/root"));
+        assert_eq!(sys.user.primary_group, "root");
+    }
+
+    #[test]
+    fn synthesize_system_honours_per_machine_override() {
+        let mut machine = debian_machine();
+        machine.user = Some(lusid_machine::MachineUser {
+            name: None,
+            home: Some(PathBuf::from("/srv/mikey")),
+            primary_group: Some("wheel".into()),
+        });
+        let sys = synthesize_system(&machine, "mikey");
+        assert_eq!(sys.user.name, "mikey");
+        assert_eq!(sys.user.home, PathBuf::from("/srv/mikey"));
+        assert_eq!(sys.user.primary_group, "wheel");
+    }
+}

--- a/machine/src/lib.rs
+++ b/machine/src/lib.rs
@@ -21,6 +21,15 @@ pub struct Machine {
     pub os: Os,
     pub vm: Option<MachineVmOptions>,
     pub remote: Option<Remote>,
+    /// Overrides for the synthetic `lusid_system::User` used when the operator
+    /// plans for this target offline (remote/dev apply file discovery). Fields
+    /// default to Debian/Arch user-private-group conventions: `name` from the
+    /// connection user, `home = /home/<name>` (`/root` for root), and
+    /// `primary_group = name`. Set explicit values when the target deviates -
+    /// e.g. shared `users` group on legacy distros, or a non-standard home
+    /// directory.
+    #[serde(default)]
+    pub user: Option<MachineUser>,
 }
 
 /// VM-specific knobs when `Machine::vm` is `Some`. All fields are optional so
@@ -68,6 +77,17 @@ pub struct Remote {
     /// to `~/.ssh/id_ed25519`. Deliberately distinct from the `--identity`
     /// (age) flag elsewhere - these are unrelated identities.
     pub ssh_key: Option<PathBuf>,
+}
+
+/// Optional overrides for the synthetic [`lusid_system::User`] produced when
+/// the operator plans for a target offline. Unset fields fall through to
+/// convention-based defaults (see [`Machine::user`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MachineUser {
+    pub name: Option<String>,
+    pub home: Option<PathBuf>,
+    pub primary_group: Option<String>,
 }
 
 impl Remote {
@@ -156,5 +176,36 @@ os = { type = "linux", linux = "debian", debian = 13 }
         )
         .unwrap();
         assert!(m.remote.is_none());
+    }
+
+    #[test]
+    fn machine_user_override_round_trips() {
+        let m: Machine = toml::from_str(
+            r#"
+hostname = "web-a"
+arch = "x86-64"
+os = { type = "linux", linux = "debian", debian = 13 }
+user = { primary_group = "wheel", home = "/srv/mikey" }
+"#,
+        )
+        .unwrap();
+        let user = m.user.expect("user field deserialized");
+        assert_eq!(user.name, None);
+        assert_eq!(user.home, Some(PathBuf::from("/srv/mikey")));
+        assert_eq!(user.primary_group, Some("wheel".into()));
+    }
+
+    #[test]
+    fn machine_user_rejects_unknown_field() {
+        let err = toml::from_str::<Machine>(
+            r#"
+hostname = "web-a"
+arch = "x86-64"
+os = { type = "linux", linux = "debian", debian = 13 }
+user = { naem = "mikey" }
+"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown field"));
     }
 }

--- a/resource/src/lib.rs
+++ b/resource/src/lib.rs
@@ -134,6 +134,11 @@ pub trait ResourceType {
 /// produces are ordinary `Resource::File` atoms. The provenance ("this
 /// file was written for a @resource/secret plan item") is preserved only at
 /// this `ResourceParams` layer.
+///
+/// Note(cc): if you add a new variant whose params carry an *operator-side*
+/// host-path source (a file or directory the operator must ship to the
+/// target), extend `lusid::upload_set::collect_host_paths` so the source
+/// lands in the upload manifest. Today only `File`/`Directory` qualify.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ResourceParams {
     Apt(AptParams),

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -30,9 +30,15 @@ pub trait SubStore {
 }
 
 /// Multiplexed store: dispatches a [`StoreItemId`] to the right backend.
+///
+/// `reads` records every successful read so callers can answer "which plan
+/// sources did this planning pass touch" without re-instrumenting the planner.
+/// Intended for single-threaded discovery passes; cloning a `Store` produces an
+/// independent tracker that won't see reads done through the original.
 #[derive(Debug, Clone)]
 pub struct Store {
     local_file_store: LocalFileStore,
+    reads: Vec<StoreItemId>,
 }
 
 /// Tagged identifier for a store item - picks which backend handles the read.
@@ -51,17 +57,24 @@ impl Store {
     pub fn new(cache_dir: &Path) -> Self {
         Self {
             local_file_store: LocalFileStore::new(cache_dir.join("files")),
+            reads: Vec::new(),
         }
     }
 
     pub async fn read(&mut self, id: &StoreItemId) -> Result<Vec<u8>, StoreError> {
-        match id {
+        let bytes = match id {
             StoreItemId::LocalFile(id) => self
                 .local_file_store
                 .read(id)
                 .await
-                .map_err(StoreError::from),
-        }
+                .map_err(StoreError::from)?,
+        };
+        self.reads.push(id.clone());
+        Ok(bytes)
+    }
+
+    pub fn reads(&self) -> &[StoreItemId] {
+        &self.reads
     }
 }
 


### PR DESCRIPTION
## Problem

  `remote apply` and `dev apply` upload only `plan.parent()` over SFTP. Any plan that references a sibling — `module:
  "../../plans/base.lusid"`, `source: "../files/foo"` — breaks on the target with a missing-file error mid-apply.

  ## Solution

  Run the planner offline on the operator, then ship exactly the files it touched.

  - Synthesize a `System` from the machine config (Debian/Arch user-private-group conventions; override via `[machines.<id>.user]`).
  - Walk the resulting `PlanTree` for `@resource/file` and `@resource/directory` host-path sources.
  - New `Store::reads` tracker records every plan source loaded during planning.
  - Lexically normalize via `path-clean`, rebase against `config.root()`, error if a path escapes the root.
  - Mirror under `/var/lib/lusid/project/` (replacing `/var/lib/lusid/plan/`); `--root` and `--plan` to `lusid-apply` now point at that
  mirror, retiring the TODO about meaningless `--root`. Same change for `dev apply` under `<dev_dir>/project/`.

  Discovery runs before any SSH/VM work, so plan errors surface fast and clearly.

  ## Notes

  - Legacy `<root>/plan` gets a one-shot best-effort cleanup (gated on `test -d` to keep `sudo` out of the audit log when there's nothing to
   remove).
  - New `Note(cc)` on `ResourceParams`: future variants with operator-side host paths must extend `upload_set::collect_host_paths`.
  - Wormfarm only uses `system.user.home` and `system.hostname` in real plans (no branches on `system.*`), so synthesizing is safe for
  current use.

  ## Test plan

  - [ ] `cargo test --workspace --lib` (111 lusid tests pass, including new `upload_set` coverage)
  - [ ] `cargo clippy --workspace --all-targets -- -D warnings`
  - [ ] `lusid remote apply --machine <id>` against wormfarm's `rpi4b-1` (cross-dir `../../plans/base.lusid` should now ship)
  - [ ] `lusid dev apply --machine <id>` against a plan that references a sibling dir
  - [ ] Plan with a host source outside `config.root()` errors at discovery, before SSH